### PR TITLE
Scripts/os check

### DIFF
--- a/airconnect_installer.sh
+++ b/airconnect_installer.sh
@@ -60,5 +60,3 @@ EOF
   systemctl status airconnect
 
 fi
-
-

--- a/airconnect_installer.sh
+++ b/airconnect_installer.sh
@@ -7,50 +7,58 @@ if [ $(whoami) != 'root' ]; then
   exit 0
 
 
+# Check OS
+elif [ $(awk -F= '$1=="ID" { print $2 ;}' /etc/os-release) != 'raspbian' ]; then
+  echo "You are trying to install this on an unsupported distribution."
+  echo "Only the Raspberry Pi OS is supported."
+
+
 elif [ -d /var/lib/airconnect ]; then
 
-echo "Update AirConnect..."
+  echo "Update AirConnect..."
 
-cd /var/lib/airconnect
-rm airupnp-arm
-curl https://raw.githubusercontent.com/philippe44/AirConnect/master/bin/airupnp-arm -o airupnp-arm
-chmod 755 airupnp-arm
+  cd /var/lib/airconnect
+  rm airupnp-arm
+  curl https://raw.githubusercontent.com/philippe44/AirConnect/master/bin/airupnp-arm -o airupnp-arm
+  chmod 755 airupnp-arm
 
-systemctl restart airconnect
+  systemctl restart airconnect
 
-systemctl status airconnect
+  systemctl status airconnect
 
 
 else
 
-echo "Install AirConnect..."
+  echo "Install AirConnect..."
 
-mkdir /var/lib/airconnect
-cd /var/lib/airconnect
-curl https://raw.githubusercontent.com/philippe44/AirConnect/master/bin/airupnp-arm -o airupnp-arm
-chmod 755 airupnp-arm
+  mkdir /var/lib/airconnect
+  cd /var/lib/airconnect
+  curl https://raw.githubusercontent.com/philippe44/AirConnect/master/bin/airupnp-arm -o airupnp-arm
+  chmod 755 airupnp-arm
 
-cd /etc/systemd/system/
-cat > airconnect.service <<EOF
-[Unit]
-Description=AirUPnP bridge
-After=network-online.target
-Wants=network-online.target
+  cd /etc/systemd/system/
+  cat > airconnect.service <<EOF
+  [Unit]
+  Description=AirUPnP bridge
+  After=network-online.target
+  Wants=network-online.target
 
-[Service]
-Type=forking
-ExecStart=/var/lib/airconnect/airupnp-arm -l 1000:2000 -z -f /var/log/airupnp.log
-Restart=on-failure
-RestartSec=30
+  [Service]
+  Type=forking
+  ExecStart=/var/lib/airconnect/airupnp-arm -l 1000:2000 -z -f /var/log/airupnp.log
+  Restart=on-failure
+  RestartSec=30
 
-[Install]
-WantedBy=multi-user.target
+  [Install]
+  WantedBy=multi-user.target
 EOF
 
-cd /var/lib/airconnect
+  cd /var/lib/airconnect
 
-systemctl enable --now airconnect
+  systemctl enable --now airconnect
 
-systemctl status airconnect
+  systemctl status airconnect
 
 fi
+
+

--- a/airconnect_uninstaller.sh
+++ b/airconnect_uninstaller.sh
@@ -7,23 +7,30 @@ if [ $(whoami) != 'root' ]; then
   exit 0
 
 
+# Check OS
+elif [ $(awk -F= '$1=="ID" { print $2 ;}' /etc/os-release) != 'raspbian' ]; then
+  echo "You are trying to install this on an unsupported distribution."
+  echo "Only the Raspberry Pi OS is supported."
+
+
 elif [ -d /var/lib/airconnect ]; then
 
-echo "Uninstall AirConnect..."
+  echo "Uninstall AirConnect..."
 
-systemctl disable --now airconnect
+  systemctl disable --now airconnect
 
-rm -rf /var/lib/airconnect
+  rm -rf /var/lib/airconnect
 
-rm /etc/systemd/system/airconnect.service 
+  rm /etc/systemd/system/airconnect.service 
 
-rm /var/log/airupnp.log
-
+  rm /var/log/airupnp.log
 
 else
 	
-echo "AirConnect has already been uninstalled."
-echo "For reinstallation use the installer script."
-exit 0
+  echo "AirConnect has already been uninstalled."
+  echo "For reinstallation use the installer script."
+  exit 0
 
 fi
+
+

--- a/airconnect_uninstaller.sh
+++ b/airconnect_uninstaller.sh
@@ -32,5 +32,3 @@ else
   exit 0
 
 fi
-
-


### PR DESCRIPTION
Check of OS is now working correct tested on debian docker image:
```
root@ab4353b224e2:/rpi_configs# ./airconnect_installer.sh 
You are trying to install this on an unsupported distribution.
Only the Raspberry Pi OS is supported.
```