### PR TITLE
Huge Refactor: Check OS and Architecture detection

### DIFF
--- a/airconnect_installer
+++ b/airconnect_installer
@@ -12,11 +12,11 @@ if [ $(whoami) != 'root' ]; then
 
 OS_ID=$(cat /etc/os-release |grep "ID=" |cut -c 4-)
 
-elif [ "${OS_ID}" != "debian" ]  && [ "${OS_ID}" != "debian" ] && [ "${OS_ID}" != "ubuntu" ]; then
+elif [ $(uname -s) != "Linux" ]; then
   YELLOW='\033[1;33m'
   NC='\033[0m'
-  echo "${YELLOW}You are trying to install this on an unsupported distribution."
-  echo "Supported distributions are: Raspberry Pi OS 32/64 bit, Debian (ARM image), Ubuntu (ARM image).${NC}"
+  echo "${YELLOW}You are trying to install this on an unsupported System."
+  echo "This Installer is only supported by Linux Distributions.${NC}"
   exit 0
 
 elif [ -d /var/lib/airconnect ]; then

--- a/airconnect_installer
+++ b/airconnect_installer
@@ -10,11 +10,13 @@ if [ $(whoami) != 'root' ]; then
 
 # Check OS
 
-elif [ $(awk -F= '$1=="ID" { print $2 ;}' /etc/os-release) != 'debian' ]; then
+OS_ID=$(cat /etc/os-release |grep "ID=" |cut -c 4-)
+
+elif [ "${OS_ID}" != "debian" ]  && [ "${OS_ID}" != "debian" ] && [ "${OS_ID}" != "ubuntu" ]; then
   YELLOW='\033[1;33m'
   NC='\033[0m'
   echo "${YELLOW}You are trying to install this on an unsupported distribution."
-  echo "Only the Raspberry Pi OS 64-bit is supported.${NC}"
+  echo "Supported distributions are: Raspberry Pi OS 32/64 bit, Debian (ARM image), Ubuntu (ARM image).${NC}"
   exit 0
 
 elif [ -d /var/lib/airconnect ]; then
@@ -24,7 +26,8 @@ elif [ -d /var/lib/airconnect ]; then
 
   cd /var/lib/airconnect
   rm -f *
-  curl --progress-bar https://raw.githubusercontent.com/philippe44/AirConnect/master/bin/airupnp-linux-aarch64 -o airupnp-arm
+  arch=$(uname -m)
+  curl --progress-bar https://raw.githubusercontent.com/philippe44/AirConnect/master/bin/airupnp-linux-${arch} -o airupnp-arm
   chmod 755 airupnp-arm
   
   systemctl daemon-reload
@@ -41,7 +44,8 @@ else
 
   mkdir /var/lib/airconnect
   cd /var/lib/airconnect
-  curl --progress-bar https://raw.githubusercontent.com/philippe44/AirConnect/master/bin/airupnp-linux-aarch64 -o airupnp-arm
+  arch=$(uname -m)
+  curl --progress-bar https://raw.githubusercontent.com/philippe44/AirConnect/master/bin/airupnp-linux-${arch} -o airupnp-arm
   chmod 755 airupnp-arm
 
   cd /etc/systemd/system/


### PR DESCRIPTION
- More than one Linux ARM / x86_64 Distributions can be detected.
- Architectures will be detected as well and curl will download the right binary file.

Signed-off-by: Philip Heiduck <no-public-mail@github.com>