### PR TITLE
Security: add os check to uninstaller

### DIFF
--- a/airconnect_uninstaller
+++ b/airconnect_uninstaller
@@ -8,6 +8,17 @@ if [ $(whoami) != 'root' ]; then
   echo "${YELLOW}Please run with sudo privileges${NC}"
   exit 0
 
+# Check OS
+
+elif [ $(awk -F= '$1=="ID" { print $2 ;}' /etc/os-release) != 'debian' ]; then
+  YELLOW='\033[1;33m'
+  RED='\033[0;31m'
+  NC='\033[0m'
+  echo "${RED}=======================ERROR=======================${NC}"
+  echo "${YELLOW}Don't use the uninstaller on unspported Systems!"
+  echo "This Uninstaller is only supported by Linux Distributions.${NC}"
+  exit 0
+
 elif [ -d /var/lib/airconnect ]; then
   RED='\033[0;31m'
   NC='\033[0m'
@@ -20,6 +31,7 @@ elif [ -d /var/lib/airconnect ]; then
   rm /etc/systemd/system/airupnp.service 
 
 else
+
   YELLOW='\033[0;33m'
   NC='\033[0m'
   echo "${YELLOW}AirConnect has already been uninstalled."


### PR DESCRIPTION
hardening security for uninstaller, so it can't be used on unsupported Systems