### PR TITLE
fixup: use curl commandline options to setup output-dir

### DIFF
--- a/airconnect_installer
+++ b/airconnect_installer
@@ -40,9 +40,8 @@ else
   NC='\033[0m'
   echo "${GREEN}Install AirConnect...${NC}"
 
-  mkdir /var/lib/airconnect
+  curl --compressed --progress-bar https://raw.githubusercontent.com/philippe44/AirConnect/master/bin/airupnp-linux-$(uname -m) -o airupnp-arm --output-dir /var/lib/airconnect --create-dirs
   cd /var/lib/airconnect
-  curl --compressed --progress-bar https://raw.githubusercontent.com/philippe44/AirConnect/master/bin/airupnp-linux-$(uname -m) -o airupnp-arm
   chmod 755 airupnp-arm
 
   cd /etc/systemd/system/


### PR DESCRIPTION
learned in the curl session: https://www.youtube.com/watch?v=V5vZWHP-RqU&pp=ygUObWFzdGVyaW5nIGN1cmw%3D
**Note:**
We may need to drop ubuntu 20.04 support due it uses a older curl version which does not support this commandline options.